### PR TITLE
Improved as_common_basis()

### DIFF
--- a/examples/linalg.py
+++ b/examples/linalg.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import numpy as np
 
 from slate.array import SlateArray
-from slate.basis import fundamental_tuple_basis_from_shape
+from slate.basis import fundamental_basis_from_shape
 from slate.linalg import get_eigenvalues, into_diagonal
 
 if __name__ == "__main__":
     rng = np.random.default_rng()
     data = rng.random((10, 10)) + 1j * rng.random((10, 10))
-    array = SlateArray(fundamental_tuple_basis_from_shape((10, 10)), data)
+    array = SlateArray(fundamental_basis_from_shape((10, 10)), data)
 
     diagonal = into_diagonal(array)
     eigenvalues = get_eigenvalues(array)

--- a/slate/array/_util.py
+++ b/slate/array/_util.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 from slate.array._array import SlateArray
-from slate.basis.wrapped import as_index_basis
+from slate.basis import as_index_basis
 from slate.metadata import BasisMetadata
 
 

--- a/slate/basis/__init__.py
+++ b/slate/basis/__init__.py
@@ -18,6 +18,7 @@ from slate.basis._tuple import (
     as_tuple_basis,
     fundamental_tuple_basis_from_metadata,
     fundamental_tuple_basis_from_shape,
+    get_common_basis,
     tuple_basis,
     tuple_basis_is_variadic,
     tuple_basis_with_child,
@@ -42,7 +43,6 @@ from slate.basis.wrapped import (
     as_index_basis,
     as_mul_basis,
     as_sub_basis,
-    get_common_basis,
     get_wrapped_basis_super_inner,
 )
 

--- a/slate/basis/__init__.py
+++ b/slate/basis/__init__.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from slate.basis._basis import (
     Basis,
     BasisFeature,
+    NestedBool,
+    NestedBoolOrNone,
+    are_basis_dual,
 )
 from slate.basis._diagonal import DiagonalBasis, as_diagonal_basis, diagonal_basis
 from slate.basis._isotropic import IsotropicBasis, isotropic_basis
@@ -16,14 +19,21 @@ from slate.basis._tuple import (
     TupleBasis3D,
     TupleBasisND,
     as_tuple_basis,
-    fundamental_tuple_basis_from_metadata,
-    fundamental_tuple_basis_from_shape,
+    fundamental_basis_from_metadata,
+    fundamental_basis_from_shape,
     get_common_basis,
     tuple_basis,
     tuple_basis_is_variadic,
     tuple_basis_with_child,
     tuple_basis_with_modified_child,
     tuple_basis_with_modified_children,
+)
+from slate.basis._util import (
+    as_add_basis,
+    as_feature_basis,
+    as_index_basis,
+    as_mul_basis,
+    as_sub_basis,
 )
 from slate.basis.coordinate import CoordinateBasis
 from slate.basis.cropped import CroppedBasis
@@ -38,11 +48,6 @@ from slate.basis.transformed import (
 from slate.basis.truncated import Padding, TruncatedBasis, Truncation
 from slate.basis.wrapped import (
     WrappedBasis,
-    as_add_basis,
-    as_feature_basis,
-    as_index_basis,
-    as_mul_basis,
-    as_sub_basis,
     get_wrapped_basis_super_inner,
 )
 
@@ -54,6 +59,8 @@ __all__ = [
     "DiagonalBasis",
     "FundamentalBasis",
     "IsotropicBasis",
+    "NestedBool",
+    "NestedBoolOrNone",
     "Padding",
     "RecastBasis",
     "SplitBasis",
@@ -67,6 +74,7 @@ __all__ = [
     "TupleBasis3D",
     "TupleBasisND",
     "WrappedBasis",
+    "are_basis_dual",
     "as_add_basis",
     "as_diagonal_basis",
     "as_feature_basis",
@@ -75,10 +83,10 @@ __all__ = [
     "as_sub_basis",
     "as_tuple_basis",
     "diagonal_basis",
+    "fundamental_basis_from_metadata",
+    "fundamental_basis_from_shape",
     "fundamental_transformed_tuple_basis_from_metadata",
     "fundamental_transformed_tuple_basis_from_shape",
-    "fundamental_tuple_basis_from_metadata",
-    "fundamental_tuple_basis_from_shape",
     "get_common_basis",
     "get_wrapped_basis_super_inner",
     "isotropic_basis",

--- a/slate/basis/_tuple.py
+++ b/slate/basis/_tuple.py
@@ -112,6 +112,8 @@ class TupleBasis[
         self: Self,
         children: tuple[Basis[M, Any], ...],
         extra_metadata: E,
+        *,
+        is_dual: bool = False,
     ) -> None:
         self._children = children
 
@@ -120,6 +122,7 @@ class TupleBasis[
                 _InnerM,
                 StackedMetadata(tuple(i.metadata() for i in children), extra_metadata),
             ),
+            is_dual=is_dual,
         )
 
     @override

--- a/slate/basis/_util.py
+++ b/slate/basis/_util.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from slate.basis._tuple import fundamental_basis_from_metadata
+from slate.basis.wrapped import wrapped_basis_iter_inner
+from slate.metadata import BasisMetadata
+
+if TYPE_CHECKING:
+    from slate.basis._basis import Basis, BasisFeature
+
+
+def as_feature_basis[M: BasisMetadata, DT: np.generic](
+    basis: Basis[M, DT], features: set[BasisFeature]
+) -> Basis[M, DT]:
+    """Get the closest basis that supports the feature set."""
+    return next(
+        (b for b in wrapped_basis_iter_inner(basis) if features <= b.features),
+        fundamental_basis_from_metadata(basis.metadata()),
+    )
+
+
+def as_add_basis[M: BasisMetadata, DT: np.generic](
+    basis: Basis[M, DT],
+) -> Basis[M, DT]:
+    """Get the closest basis that supports addition.
+
+    If the basis is already an ADD basis, return it.
+    If it wraps an ADD basis, return the inner basis.
+    Otherwise, return the fundamental.
+    """
+    return as_feature_basis(basis, {"ADD"})
+
+
+def as_sub_basis[M: BasisMetadata, DT: np.generic](
+    basis: Basis[M, DT],
+) -> Basis[M, DT]:
+    """Get the closest basis that supports subtraction.
+
+    If the basis is already a SUB basis, return it.
+    If it wraps a SUB basis, return the inner basis.
+    Otherwise, return the fundamental.
+    """
+    return as_feature_basis(basis, {"SUB"})
+
+
+def as_mul_basis[M: BasisMetadata, DT: np.generic](
+    basis: Basis[M, DT],
+) -> Basis[M, DT]:
+    """Get the closest basis that supports MUL.
+
+    If the basis is already a MUL basis, return it.
+    If it wraps a MUL basis, return the inner basis.
+    Otherwise, return the fundamental.
+    """
+    return as_feature_basis(basis, {"MUL"})
+
+
+def as_index_basis[M: BasisMetadata, DT: np.generic](
+    basis: Basis[M, DT],
+) -> Basis[M, DT]:
+    """Get the closest basis that supports INDEX.
+
+    If the basis is already an INDEX basis, return it.
+    If it wraps a INDEX basis, return the inner basis.
+    Otherwise, return the fundamental.
+    """
+    return as_feature_basis(basis, {"INDEX"})

--- a/slate/basis/coordinate.py
+++ b/slate/basis/coordinate.py
@@ -42,7 +42,6 @@ class CoordinateBasis[M: BasisMetadata, DT: np.generic](  # noqa: PLW1641
             return (
                 np.allclose(self.inner_points, other.inner_points)
                 and other._inner == self._inner  # type: ignore unknown
-                and self.is_dual == other.is_dual
             )
         return False
 

--- a/slate/basis/cropped.py
+++ b/slate/basis/cropped.py
@@ -26,15 +26,13 @@ class CroppedBasis[M: BasisMetadata, DT: np.generic](WrappedBasis[M, DT, Basis[M
     def __eq__(self, other: object) -> bool:
         if isinstance(other, CroppedBasis):
             return (
-                self._size == other._size
-                and other._inner == self._inner  # type: ignore unknown
-                and self.is_dual == other.is_dual
+                self._size == other._size and other._inner == self._inner  # type: ignore unknown
             )
         return False
 
     @override
     def __hash__(self) -> int:
-        return hash((self._size, self._inner, self.is_dual))
+        return hash((self._size, self._inner))
 
     @override
     def __into_inner__[DT1: np.generic](  # [DT1: DT]

--- a/slate/basis/split.py
+++ b/slate/basis/split.py
@@ -6,8 +6,9 @@ from typing import TYPE_CHECKING, Any, Callable, Never, Self, cast, override
 import numpy as np
 
 from slate.basis._basis import Basis, BasisFeature
+from slate.basis._tuple import get_common_basis
 from slate.basis.transformed import TransformedBasis
-from slate.basis.wrapped import WrappedBasis, get_common_basis
+from slate.basis.wrapped import WrappedBasis
 from slate.util import Padding, pad_along_axis, slice_along_axis
 
 if TYPE_CHECKING:

--- a/slate/basis/split.py
+++ b/slate/basis/split.py
@@ -61,7 +61,6 @@ class SplitBasis[
             return (
                 other.lhs == self.lhs  # type: ignore unknown
                 and other.rhs == self.rhs  # type: ignore unknown
-                and self.is_dual == other.is_dual
             )
         return False
 
@@ -75,7 +74,7 @@ class SplitBasis[
 
     @override
     def __hash__(self) -> int:
-        return hash((1, hash(self._lhs), hash(self._rhs), self.is_dual))
+        return hash((1, hash(self._lhs), hash(self._rhs)))
 
     @property
     @override

--- a/slate/basis/transformed.py
+++ b/slate/basis/transformed.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Self, cast, overload, override
+from typing import TYPE_CHECKING, Any, Callable, Literal, Self, cast, overload, override
 
 import numpy as np
 
-from slate.basis._basis import Basis, BasisFeature
-from slate.basis._tuple import TupleBasis
-from slate.basis.fundamental import FundamentalBasis
+from slate.basis._basis import Basis, BasisFeature, NestedBoolOrNone
+from slate.basis._tuple import TupleBasis, fundamental_basis_from_metadata
 from slate.basis.wrapped import WrappedBasis
 from slate.metadata import (
+    AnyMetadata,
     BasisMetadata,
     Metadata1D,
     Metadata2D,
@@ -20,14 +20,26 @@ if TYPE_CHECKING:
     from slate.basis._tuple import TupleBasis1D, TupleBasis2D, TupleBasis3D
     from slate.metadata import SimpleMetadata
 
+type TransformDirection = Literal["forward", "backward"]
+
 
 class TransformedBasis[M: BasisMetadata](
     WrappedBasis[M, np.complex128, Basis[M, np.complex128]],
 ):
     """Represents a fourier transformed basis."""
 
-    def __init__(self: Self, inner: Basis[M, np.complex128]) -> None:
+    def __init__(
+        self: Self,
+        inner: Basis[M, np.complex128],
+        direction: TransformDirection = "forward",
+    ) -> None:
+        self._direction: TransformDirection = direction
         super().__init__(inner)
+
+    @property
+    def direction(self: Self) -> TransformDirection:
+        """Direction of the transformation."""
+        return self._direction
 
     @override
     def __eq__(self, other: object) -> bool:
@@ -35,13 +47,19 @@ class TransformedBasis[M: BasisMetadata](
             return (
                 self.size == other.size
                 and other.inner == self.inner  # type: ignore unknown
-                and self.is_dual == other.is_dual
+                and other.direction == self.direction
             )
         return False
 
     @override
+    def dual_basis(self) -> Self:
+        copied = super().dual_basis()
+        copied._direction = "backward" if self.direction == "forward" else "forward"  # noqa: SLF001
+        return copied
+
+    @override
     def __hash__(self) -> int:
-        return hash((1, self.inner, self.is_dual))
+        return hash((1, self.inner, self.direction))
 
     @property
     @override
@@ -79,7 +97,7 @@ class TransformedBasis[M: BasisMetadata](
     ) -> np.ndarray[Any, np.dtype[DT1]]:
         return (
             self._transform_backward(vectors, axis)
-            if not self.is_dual
+            if self.direction == "forward"
             else self._transform_forward(vectors, axis)
         )
 
@@ -91,7 +109,7 @@ class TransformedBasis[M: BasisMetadata](
     ) -> np.ndarray[Any, np.dtype[DT1]]:
         return (
             self._transform_forward(vectors, axis)
-            if not self.is_dual
+            if self.direction == "forward"
             else self._transform_backward(vectors, axis)
         )
 
@@ -159,29 +177,29 @@ class TransformedBasis[M: BasisMetadata](
 
 
 @overload
-def fundamental_transformed_tuple_basis_from_metadata[M0: BasisMetadata, E](
-    metadata: Metadata1D[M0, E],
+def fundamental_transformed_tuple_basis_from_metadata[M0: SimpleMetadata, E](
+    metadata: Metadata1D[M0, E], *, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis1D[np.generic, TransformedBasis[M0], E]: ...
 
 
 @overload
 def fundamental_transformed_tuple_basis_from_metadata[
-    M0: BasisMetadata,
-    M1: BasisMetadata,
+    M0: SimpleMetadata,
+    M1: SimpleMetadata,
     E,
 ](
-    metadata: Metadata2D[M0, M1, E],
+    metadata: Metadata2D[M0, M1, E], *, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis2D[np.generic, TransformedBasis[M0], TransformedBasis[M1], E]: ...
 
 
 @overload
 def fundamental_transformed_tuple_basis_from_metadata[
-    M0: BasisMetadata,
-    M1: BasisMetadata,
-    M2: BasisMetadata,
+    M0: SimpleMetadata,
+    M1: SimpleMetadata,
+    M2: SimpleMetadata,
     E,
 ](
-    metadata: Metadata3D[M0, M1, M2, E],
+    metadata: Metadata3D[M0, M1, M2, E], *, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis3D[
     np.generic,
     TransformedBasis[M0],
@@ -192,34 +210,42 @@ def fundamental_transformed_tuple_basis_from_metadata[
 
 
 @overload
-def fundamental_transformed_tuple_basis_from_metadata[M: BasisMetadata, E](
-    metadata: StackedMetadata[M, E],
+def fundamental_transformed_tuple_basis_from_metadata[M: AnyMetadata, E](
+    metadata: StackedMetadata[M, E], *, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis[M, E, np.generic]: ...
 
 
-def fundamental_transformed_tuple_basis_from_metadata[M: BasisMetadata, E](
-    metadata: StackedMetadata[M, E],
+def fundamental_transformed_tuple_basis_from_metadata[M: AnyMetadata, E](
+    metadata: StackedMetadata[M, E], *, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis[M, E, np.complexfloating[Any, Any]]:
     """Get a transformed fundamental basis with the given metadata."""
-    children = tuple(TransformedBasis(FundamentalBasis(c)) for c in metadata.children)
+    is_dual = (
+        is_dual
+        if isinstance(is_dual, tuple)
+        else tuple(is_dual for _ in metadata.children)
+    )
+    children = tuple(
+        TransformedBasis(fundamental_basis_from_metadata(c, is_dual=dual))
+        for c, dual in zip(metadata.children, is_dual)
+    )
     return TupleBasis(children, metadata.extra)
 
 
 @overload
 def fundamental_transformed_tuple_basis_from_shape[E](
-    shape: tuple[int], *, extra: None = None
+    shape: tuple[int], *, extra: None = None, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis1D[np.complex128, Basis[SimpleMetadata, np.complex128], None]: ...
 
 
 @overload
 def fundamental_transformed_tuple_basis_from_shape[E](
-    shape: tuple[int], *, extra: E
+    shape: tuple[int], *, extra: E, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis1D[np.complex128, Basis[SimpleMetadata, np.complex128], E]: ...
 
 
 @overload
 def fundamental_transformed_tuple_basis_from_shape[E](
-    shape: tuple[int, int], *, extra: None = None
+    shape: tuple[int, int], *, extra: None = None, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis2D[
     np.complex128,
     Basis[SimpleMetadata, np.complex128],
@@ -230,7 +256,7 @@ def fundamental_transformed_tuple_basis_from_shape[E](
 
 @overload
 def fundamental_transformed_tuple_basis_from_shape[E](
-    shape: tuple[int, int], *, extra: E
+    shape: tuple[int, int], *, extra: E, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis2D[
     np.complex128,
     Basis[SimpleMetadata, np.complex128],
@@ -241,7 +267,7 @@ def fundamental_transformed_tuple_basis_from_shape[E](
 
 @overload
 def fundamental_transformed_tuple_basis_from_shape[E](
-    shape: tuple[int, int, int], *, extra: None = None
+    shape: tuple[int, int, int], *, extra: None = None, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis3D[
     np.complex128,
     Basis[SimpleMetadata, np.complex128],
@@ -253,7 +279,7 @@ def fundamental_transformed_tuple_basis_from_shape[E](
 
 @overload
 def fundamental_transformed_tuple_basis_from_shape[E](
-    shape: tuple[int, int, int], *, extra: E
+    shape: tuple[int, int, int], *, extra: E, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis3D[
     np.complex128,
     Basis[SimpleMetadata, np.complex128],
@@ -265,20 +291,20 @@ def fundamental_transformed_tuple_basis_from_shape[E](
 
 @overload
 def fundamental_transformed_tuple_basis_from_shape[E](
-    shape: tuple[int, ...], *, extra: None = None
+    shape: tuple[int, ...], *, extra: None = None, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis[BasisMetadata, None, np.complex128]: ...
 
 
 @overload
 def fundamental_transformed_tuple_basis_from_shape[E](
-    shape: tuple[int, ...], *, extra: E
+    shape: tuple[int, ...], *, extra: E, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis[BasisMetadata, E, np.complex128]: ...
 
 
 def fundamental_transformed_tuple_basis_from_shape[E](
-    shape: tuple[int, ...], *, extra: E | None = None
+    shape: tuple[int, ...], *, extra: E | None = None, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis[BasisMetadata, E | None, np.complex128]:
     """Get a basis with the basis at idx set to inner."""
     return fundamental_transformed_tuple_basis_from_metadata(
-        StackedMetadata.from_shape(shape, extra=extra),
+        StackedMetadata.from_shape(shape, extra=extra), is_dual=is_dual
     )

--- a/slate/basis/truncated.py
+++ b/slate/basis/truncated.py
@@ -30,7 +30,7 @@ class TruncatedBasis[M: BasisMetadata, DT: np.generic](
 
     @override
     def __hash__(self) -> int:
-        return hash((self._inner, self._truncation, self.is_dual))
+        return hash((self._inner, self._truncation))
 
     @property
     def truncation(self: Self) -> Truncation:
@@ -47,9 +47,7 @@ class TruncatedBasis[M: BasisMetadata, DT: np.generic](
     def __eq__(self, other: object) -> bool:
         if isinstance(other, TruncatedBasis):
             return (
-                self._truncation == other._truncation
-                and other._inner == self._inner  # type: ignore unknown
-                and self.is_dual == other.is_dual
+                self._truncation == other._truncation and other._inner == self._inner  # type: ignore unknown
             )
         return False
 

--- a/slate/basis/wrapped.py
+++ b/slate/basis/wrapped.py
@@ -135,23 +135,6 @@ def get_wrapped_basis_super_inner[
     return last
 
 
-def get_common_basis[M: BasisMetadata, E, DT: np.generic](
-    rhs: Basis[M, DT],
-    lhs: Basis[M, DT],
-) -> Basis[M, DT]:
-    """Get the closest common basis of two bases."""
-    assert lhs.metadata() == rhs.metadata()
-    lhs_rev = reversed(list(wrapped_basis_iter_inner(lhs)))
-    rhs_rev = reversed(list(wrapped_basis_iter_inner(rhs)))
-
-    last_common = FundamentalBasis(lhs.metadata())
-    for a, b in zip(lhs_rev, rhs_rev):
-        if a != b:
-            return last_common
-        last_common = a
-    return last_common
-
-
 def as_feature_basis[M: BasisMetadata, DT: np.generic](
     basis: Basis[M, DT], features: set[BasisFeature]
 ) -> Basis[M, DT]:

--- a/slate/explicit_basis/_explicit_basis.py
+++ b/slate/explicit_basis/_explicit_basis.py
@@ -33,12 +33,12 @@ class ExplicitBasis[M: BasisMetadata, DT: np.generic](
 
     def __init__(
         self: Self,
-        transform: SlateArray[Metadata2D[BasisMetadata, M, Any], DT],
+        matrix: SlateArray[Metadata2D[BasisMetadata, M, Any], DT],
         *,
         direction: Direction = "forward",
         data_id: uuid.UUID | None = None,
     ) -> None:
-        self._matrix = transform
+        self._matrix = matrix
         self._direction: Direction = direction
         self._data_id = data_id or uuid.uuid4()
         super().__init__(as_tuple_basis(self.eigenvectors.basis)[1])
@@ -245,13 +245,13 @@ class ExplicitUnitaryBasis[M: BasisMetadata, DT: np.generic](ExplicitBasis[M, DT
 
     def __init__(
         self: Self,
-        eigenvectors: SlateArray[Metadata2D[BasisMetadata, M, Any], DT],
+        matrix: SlateArray[Metadata2D[BasisMetadata, M, Any], DT],
         *,
         assert_unitary: bool = False,
         direction: Direction = "forward",
         data_id: uuid.UUID | None = None,
     ) -> None:
-        super().__init__(eigenvectors, direction=direction, data_id=data_id)
+        super().__init__(matrix, direction=direction, data_id=data_id)
         if assert_unitary:
             states_tuple = self.eigenvectors.with_basis(
                 as_tuple_basis(self.eigenvectors.basis)

--- a/slate/explicit_basis/_explicit_basis.py
+++ b/slate/explicit_basis/_explicit_basis.py
@@ -77,8 +77,7 @@ class ExplicitBasis[M: BasisMetadata, DT: np.generic](
     def eigenvectors(
         self: Self,
     ) -> SlateArray[Metadata2D[BasisMetadata, M, None], DT]:
-        data = self.transform
-        return data.with_basis(data.basis.dual_basis())
+        return transpose(self.inverse_transform)
 
     @override
     def __eq__(self, other: object) -> bool:
@@ -287,8 +286,8 @@ class TrivialExplicitBasis[M: BasisMetadata, DT: np.generic](
     def __init__(self: Self, inner: Basis[M, DT]) -> None:
         super().__init__(
             SlateArray(
-                diagonal_basis((inner, inner.dual_basis()), self.inner.metadata()),
-                cast(np.ndarray[Any, np.dtype[DT]], np.ones(self.size)),
+                diagonal_basis((inner, inner.dual_basis())),
+                cast(np.ndarray[Any, np.dtype[DT]], np.ones(inner.size)),
             ),
             data_id=uuid.UUID(int=0),
         )

--- a/slate/explicit_basis/_explicit_basis.py
+++ b/slate/explicit_basis/_explicit_basis.py
@@ -16,6 +16,7 @@ from slate.basis import (
 )
 from slate.basis._diagonal import diagonal_basis
 from slate.metadata import BasisMetadata
+from slate.metadata._shape import size_from_nested_shape
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -87,18 +88,19 @@ class ExplicitBasis[M: BasisMetadata, DT: np.generic](
                 and other.inner == self.inner  # type: ignore unknown
                 and other.direction == self.direction
                 and other._data_id == self._data_id
-                and self.is_dual == other.is_dual
             )
         return False
 
     @override
     def __hash__(self) -> int:
-        return hash((1, self.inner, self.direction, self._data_id, self.is_dual))
+        return hash((1, self.inner, self.direction, self._data_id))
 
     @property
     @override
     def size(self: Self) -> int:
-        return self.eigenvectors.basis.fundamental_shape[0]
+        return size_from_nested_shape(
+            self.eigenvectors.basis.metadata().fundamental_shape[0]
+        )
 
     @property
     def direction(self: Self) -> Direction:

--- a/slate/linalg/_eig.py
+++ b/slate/linalg/_eig.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from slate.basis._basis import Basis
     from slate.basis._tuple import TupleBasis2D
     from slate.metadata import StackedMetadata
+    from slate.metadata._metadata import SimpleMetadata
     from slate.metadata.stacked import Metadata2D
 
 
@@ -51,11 +52,10 @@ def _diagonal_basis_as_explicit[
 
 def get_eigenvalues[M: BasisMetadata, E, DT: np.complexfloating[Any, Any]](
     array: SlateArray[StackedMetadata[M, E], DT],
-) -> SlateArray[BasisMetadata, np.complex128, FundamentalBasis[BasisMetadata]]:
+) -> SlateArray[BasisMetadata, np.complex128, FundamentalBasis[SimpleMetadata]]:
     """Get the eigenvalues of a matrix."""
     a = np.linalg.eigvals(array.as_array())
-    shape = cast(tuple[int, ...], a.shape)
-    return SlateArray(FundamentalBasis.from_shape(shape), a)
+    return SlateArray(FundamentalBasis.from_size(a.size), a)
 
 
 def _eig_from_tuple[
@@ -83,9 +83,7 @@ def _eig_from_tuple[
 
     states_basis_0 = tuple_basis(
         (
-            FundamentalBasis.from_size(
-                eig.eigenvalues.size, is_dual=array.basis[0].is_dual
-            ),
+            FundamentalBasis.from_size(eig.eigenvalues.size, is_dual=False),
             array.basis[0].dual_basis(),
         )
     )
@@ -94,9 +92,7 @@ def _eig_from_tuple[
     )
     states_basis_1 = tuple_basis(
         (
-            FundamentalBasis.from_size(
-                eig.eigenvalues.size, is_dual=array.basis[1].is_dual
-            ),
+            FundamentalBasis.from_size(eig.eigenvalues.size, is_dual=True),
             array.basis[1],
         )
     )
@@ -147,10 +143,9 @@ def into_diagonal[
 
 def get_eigenvalues_hermitian[M: BasisMetadata, E, DT: np.complexfloating[Any, Any]](
     array: SlateArray[StackedMetadata[M, E], DT],
-) -> SlateArray[BasisMetadata, np.float64, FundamentalBasis[BasisMetadata]]:
+) -> SlateArray[BasisMetadata, np.float64, FundamentalBasis[SimpleMetadata]]:
     a = np.linalg.eigvalsh(array.as_array())
-    shape = cast(tuple[int, ...], a.shape)
-    return SlateArray(FundamentalBasis.from_shape(shape), a)
+    return SlateArray(FundamentalBasis.from_size(a.size), a)
 
 
 def _eigh_from_tuple[
@@ -176,9 +171,7 @@ def _eigh_from_tuple[
 
     states_basis_0 = tuple_basis(
         (
-            FundamentalBasis.from_size(
-                eig.eigenvalues.size, is_dual=array.basis[0].is_dual
-            ),
+            FundamentalBasis.from_size(eig.eigenvalues.size, is_dual=False),
             array.basis[0].dual_basis(),
         )
     )
@@ -189,9 +182,7 @@ def _eigh_from_tuple[
     )
     states_basis_1 = tuple_basis(
         (
-            FundamentalBasis.from_size(
-                eig.eigenvalues.size, is_dual=array.basis[1].is_dual
-            ),
+            FundamentalBasis.from_size(eig.eigenvalues.size, is_dual=True),
             array.basis[1],
         )
     )

--- a/slate/metadata/__init__.py
+++ b/slate/metadata/__init__.py
@@ -11,8 +11,14 @@ from slate.metadata._metadata import (
     SimpleMetadata,
     SpacedLabeledMetadata,
 )
+from slate.metadata._shape import (
+    NestedLength,
+    shallow_shape_from_nested,
+    size_from_nested_shape,
+)
 from slate.metadata.length import LengthMetadata, SpacedLengthMetadata
 from slate.metadata.stacked import (
+    AnyMetadata,
     Metadata1D,
     Metadata2D,
     Metadata3D,
@@ -20,7 +26,6 @@ from slate.metadata.stacked import (
     StackedMetadata,
 )
 from slate.metadata.util import (
-    fundamental_ndim,
     fundamental_nk_points,
     fundamental_nx_points,
     fundamental_size,
@@ -34,6 +39,7 @@ from slate.metadata.volume import (
 )
 
 __all__ = [
+    "AnyMetadata",
     "AxisDirections",
     "BasisMetadata",
     "DeltaMetadata",
@@ -46,16 +52,18 @@ __all__ = [
     "Metadata2D",
     "Metadata3D",
     "MetadataND",
+    "NestedLength",
     "SimpleMetadata",
     "SpacedLabeledMetadata",
     "SpacedLengthMetadata",
     "SpacedVolumeMetadata",
     "StackedMetadata",
     "VolumeMetadata",
-    "fundamental_ndim",
     "fundamental_nk_points",
     "fundamental_nx_points",
     "fundamental_size",
     "fundamental_stacked_nk_points",
     "fundamental_stacked_nx_points",
+    "shallow_shape_from_nested",
+    "size_from_nested_shape",
 ]

--- a/slate/metadata/_metadata.py
+++ b/slate/metadata/_metadata.py
@@ -9,12 +9,14 @@ import numpy as np
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from slate.metadata._shape import NestedLength
+
 
 class BasisMetadata(Protocol):
     """Protocol that all Metadata should implement."""
 
     @property
-    def fundamental_shape(self: Self) -> tuple[int, ...]:
+    def fundamental_shape(self: Self) -> NestedLength:
         """Shape of the full data."""
         ...
 
@@ -27,9 +29,9 @@ class SimpleMetadata(BasisMetadata):
 
     @property
     @override
-    def fundamental_shape(self: Self) -> tuple[int, ...]:
+    def fundamental_shape(self: Self) -> int:
         """Shape of the full data."""
-        return (self.fundamental_size,)
+        return self.fundamental_size
 
 
 class LabelCollection[DT](Protocol):

--- a/slate/metadata/_shape.py
+++ b/slate/metadata/_shape.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+
+type NestedLength = Union[int, tuple[NestedLength, ...]]
+
+
+def size_from_nested_shape(shape: NestedLength) -> int:
+    """Get the size from a nested shape."""
+    if isinstance(shape, int):
+        return shape
+    return np.prod([size_from_nested_shape(sub_shape) for sub_shape in shape]).item()
+
+
+def shallow_shape_from_nested(shape: NestedLength) -> tuple[int, ...]:
+    """Get the flat shape from a nested shape."""
+    if isinstance(shape, int):
+        return (shape,)
+    return tuple(size_from_nested_shape(sub_shape) for sub_shape in shape)

--- a/slate/metadata/util.py
+++ b/slate/metadata/util.py
@@ -5,20 +5,14 @@ from typing import Any
 import numpy as np
 
 from slate.metadata import BasisMetadata, SimpleMetadata
-
-
-def fundamental_ndim(
-    metadata: BasisMetadata,
-) -> int:
-    """Get the number of dimensions."""
-    return len(metadata.fundamental_shape)
+from slate.metadata._shape import shallow_shape_from_nested, size_from_nested_shape
 
 
 def fundamental_size(
     metadata: BasisMetadata,
 ) -> int:
     """Get the size."""
-    return np.prod(metadata.fundamental_shape).item()
+    return size_from_nested_shape(metadata.fundamental_shape)
 
 
 def nx_points(size: int) -> np.ndarray[Any, np.dtype[np.int_]]:
@@ -51,8 +45,9 @@ def fundamental_stacked_nx_points(
     metadata: BasisMetadata,
 ) -> tuple[np.ndarray[Any, np.dtype[np.int_]], ...]:
     """Get the stacked index, using the x convention (0...N)."""
+    shallow_shape = shallow_shape_from_nested(metadata.fundamental_shape)
     mesh = np.meshgrid(
-        *(fundamental_nx_points(SimpleMetadata(n)) for n in metadata.fundamental_shape),
+        *(fundamental_nx_points(SimpleMetadata(n)) for n in shallow_shape),
         indexing="ij",
     )
     return tuple(nki.ravel() for nki in mesh)
@@ -62,8 +57,9 @@ def fundamental_stacked_nk_points(
     metadata: BasisMetadata,
 ) -> tuple[np.ndarray[Any, np.dtype[np.int_]], ...]:
     """Get the stacked index, using the kx convention (0...N/2-N/2...)."""
+    shallow_shape = shallow_shape_from_nested(metadata.fundamental_shape)
     mesh = np.meshgrid(
-        *(fundamental_nk_points(SimpleMetadata(n)) for n in metadata.fundamental_shape),
+        *(fundamental_nk_points(SimpleMetadata(n)) for n in shallow_shape),
         indexing="ij",
     )
     return tuple(nki.ravel() for nki in mesh)

--- a/slate/plot/_animate.py
+++ b/slate/plot/_animate.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from matplotlib.animation import ArtistAnimation
 
+from slate.metadata._shape import shallow_shape_from_nested
 from slate.plot._plot import (
     plot_data_1d_k,
     plot_data_1d_n,
@@ -70,11 +71,12 @@ def animate_data_1d_n[DT: np.number[Any]](  # noqa: PLR0913
     tuple[Figure, Axes, ArtistAnimation]
     """
     fig, ax = get_figure(ax)
-    idx = tuple(np.zeros(data.basis.n_dim - 2)) if idx is None else idx
+    shape = shallow_shape_from_nested(data.basis.fundamental_shape)
+    idx = tuple(np.zeros(len(shape) - 2)) if idx is None else idx
 
     frames: list[list[Line2D]] = []
 
-    for idx_x0 in range(data.basis.fundamental_shape[axes[0]]):
+    for idx_x0 in range(shape[axes[0]]):
         _, _, line = plot_data_1d_n(
             data,
             axes[1:],
@@ -124,11 +126,12 @@ def animate_data_1d_x[DT: np.number[Any]](  # noqa: PLR0913
     tuple[Figure, Axes, ArtistAnimation]
     """
     fig, ax = get_figure(ax)
-    idx = tuple(np.zeros(data.basis.n_dim - 2)) if idx is None else idx
+    shape = shallow_shape_from_nested(data.basis.fundamental_shape)
+    idx = tuple(np.zeros(len(shape) - 2)) if idx is None else idx
 
     frames: list[list[Line2D]] = []
 
-    for idx_x0 in range(data.basis.fundamental_shape[axes[0]]):
+    for idx_x0 in range(shape[axes[0]]):
         _, _, line = plot_data_1d_x(
             data,
             axes[1:],
@@ -176,11 +179,12 @@ def animate_data_1d_k[DT: np.number[Any]](  # noqa: PLR0913
     tuple[Figure, Axes, ArtistAnimation]
     """
     fig, ax = get_figure(ax)
-    idx = tuple(np.zeros(data.basis.n_dim - 2)) if idx is None else idx
+    shape = shallow_shape_from_nested(data.basis.fundamental_shape)
+    idx = tuple(np.zeros(len(shape) - 2)) if idx is None else idx
 
     frames: list[list[Line2D]] = []
 
-    for idx_x0 in range(data.basis.fundamental_shape[axes[0]]):
+    for idx_x0 in range(shape[axes[0]]):
         _, _, line = plot_data_1d_k(
             data,
             axes[1:],
@@ -229,11 +233,12 @@ def animate_data_2d_x[DT: np.number[Any]](  # noqa: PLR0913
     tuple[Figure, Axes, ArtistAnimation]
     """
     fig, ax = get_figure(ax)
-    idx = tuple(np.zeros(data.basis.n_dim - 3)) if idx is None else idx
+    shape = shallow_shape_from_nested(data.basis.fundamental_shape)
+    idx = tuple(np.zeros(len(shape) - 2)) if idx is None else idx
 
     frames: list[list[QuadMesh]] = []
 
-    for idx_x0 in range(data.basis.fundamental_shape[axes[0]]):
+    for idx_x0 in range(shape[axes[0]]):
         _, _, mesh = plot_data_2d_x(
             data,
             axes[1:],
@@ -280,10 +285,11 @@ def animate_data_2d_k[DT: np.number[Any]](  # noqa: PLR0913
     tuple[Figure, Axes, ArtistAnimation]
     """
     fig, ax = get_figure(ax)
-    idx = tuple(np.zeros(data.basis.n_dim - 3)) if idx is None else idx
+    shape = shallow_shape_from_nested(data.basis.fundamental_shape)
+    idx = tuple(np.zeros(len(shape) - 2)) if idx is None else idx
 
     frames: list[list[QuadMesh]] = []
-    for idx_x0 in range(data.basis.fundamental_shape[axes[0]]):
+    for idx_x0 in range(shape[axes[0]]):
         _, _, mesh = plot_data_2d_k(
             data,
             axes[1:],

--- a/slate/plot/_plot.py
+++ b/slate/plot/_plot.py
@@ -6,8 +6,8 @@ import numpy as np
 
 from slate.basis import (
     as_tuple_basis,
+    fundamental_basis_from_metadata,
     fundamental_transformed_tuple_basis_from_metadata,
-    fundamental_tuple_basis_from_metadata,
 )
 from slate.metadata.volume import (
     get_k_coordinates_in_axes,
@@ -162,7 +162,9 @@ def plot_data_1d_k[DT: np.number[Any]](
     -------
     tuple[Figure, Axes, Line2D]
     """
-    basis_k = fundamental_transformed_tuple_basis_from_metadata(data.basis.metadata())
+    basis_k = fundamental_transformed_tuple_basis_from_metadata(
+        data.basis.metadata(), is_dual=data.basis.is_dual
+    )
     converted_data = data.with_basis(basis_k).raw_data.reshape(basis_k.shape)
 
     idx = get_max_idx(converted_data, axes) if idx is None else idx
@@ -209,7 +211,9 @@ def plot_data_1d_x[DT: np.number[Any]](
     -------
     tuple[Figure, Axes, Line2D]
     """
-    basis_x = fundamental_tuple_basis_from_metadata(data.basis.metadata())
+    basis_x = fundamental_basis_from_metadata(
+        data.basis.metadata(), is_dual=data.basis.is_dual
+    )
     converted_data = data.with_basis(basis_x).raw_data.reshape(basis_x.shape)
 
     idx = get_max_idx(converted_data, axes) if idx is None else idx
@@ -301,7 +305,9 @@ def plot_data_2d_k[DT: np.number[Any]](
     -------
     tuple[Figure, Axes, QuadMesh]
     """
-    basis_k = fundamental_transformed_tuple_basis_from_metadata(data.basis.metadata())
+    basis_k = fundamental_transformed_tuple_basis_from_metadata(
+        data.basis.metadata(), is_dual=data.basis.is_dual
+    )
     converted_data = data.with_basis(basis_k).raw_data.reshape(basis_k.shape)
 
     idx = get_max_idx(converted_data, axes) if idx is None else idx
@@ -358,7 +364,9 @@ def plot_data_2d_x[DT: np.number[Any]](
     -------
     tuple[Figure, Axes, QuadMesh]
     """
-    basis_x = fundamental_tuple_basis_from_metadata(data.basis.metadata())
+    basis_x = fundamental_basis_from_metadata(
+        data.basis.metadata(), is_dual=data.basis.is_dual
+    )
     converted_data = data.with_basis(basis_x).raw_data.reshape(basis_x.shape)
 
     idx = get_max_idx(converted_data, axes) if idx is None else idx

--- a/tests/conversion_test.py
+++ b/tests/conversion_test.py
@@ -13,7 +13,7 @@ from slate.basis import (
     TruncatedBasis,
     Truncation,
     diagonal_basis,
-    fundamental_tuple_basis_from_shape,
+    fundamental_basis_from_shape,
     tuple_basis,
 )
 from slate.basis.transformed import fundamental_transformed_tuple_basis_from_shape
@@ -91,7 +91,7 @@ def test_transformed_basis() -> None:
 
 
 def test_diagonal_basis_round_trip() -> None:
-    full_basis = fundamental_tuple_basis_from_shape((10, 10))
+    full_basis = fundamental_basis_from_shape((10, 10))
     basis_diagonal = diagonal_basis(full_basis.children)
 
     array = SlateArray(full_basis, np.diag(np.ones(10)))
@@ -128,7 +128,7 @@ def test_diagonal_basis_round_trip() -> None:
 
 
 def test_transform_spaced_basis() -> None:
-    half_basis = fundamental_tuple_basis_from_shape((105,))
+    half_basis = fundamental_basis_from_shape((105,))
     full_basis = tuple_basis((half_basis, half_basis))
     spaced_basis = TruncatedBasis(Truncation(3, 5, 0), TransformedBasis(half_basis))
 
@@ -168,10 +168,10 @@ def test_transform_spaced_basis() -> None:
 @pytest.mark.parametrize(
     "basis",
     [
-        fundamental_tuple_basis_from_shape((10, 10)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(False, True)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(True, False)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(True, True)),
+        fundamental_basis_from_shape((10, 10)),
+        fundamental_basis_from_shape((10, 10), is_dual=(False, True)),
+        fundamental_basis_from_shape((10, 10), is_dual=(True, False)),
+        fundamental_basis_from_shape((10, 10), is_dual=(True, True)),
         fundamental_transformed_tuple_basis_from_shape((10, 10)),
     ],
 )
@@ -183,7 +183,7 @@ def test_dual_basis_transform(
         None,
     ],
 ) -> None:
-    basis = fundamental_tuple_basis_from_shape((10, 10))
+    basis = fundamental_basis_from_shape((10, 10))
 
     dual_basis = basis.dual_basis()
     dual_child_basis = tuple_basis(

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -9,7 +9,7 @@ from slate.array import SlateArray, convert_array
 from slate.basis._tuple import (
     TupleBasis2D,
     as_tuple_basis,
-    fundamental_tuple_basis_from_shape,
+    fundamental_basis_from_shape,
 )
 from slate.linalg import into_diagonal
 from slate.linalg._eig import (
@@ -72,10 +72,10 @@ def _test_into_diagonal(
 @pytest.mark.parametrize(
     "basis",
     [
-        fundamental_tuple_basis_from_shape((10, 10)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(False, True)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(True, False)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(True, True)),
+        fundamental_basis_from_shape((10, 10)),
+        fundamental_basis_from_shape((10, 10), is_dual=(False, True)),
+        fundamental_basis_from_shape((10, 10), is_dual=(True, False)),
+        fundamental_basis_from_shape((10, 10), is_dual=(True, True)),
     ],
 )
 def test_linalg_complex(
@@ -130,10 +130,10 @@ def _test_into_diagonal_hermitian(
 @pytest.mark.parametrize(
     "basis",
     [
-        fundamental_tuple_basis_from_shape((10, 10)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(False, True)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(True, False)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(True, True)),
+        fundamental_basis_from_shape((10, 10)),
+        fundamental_basis_from_shape((10, 10), is_dual=(False, True)),
+        fundamental_basis_from_shape((10, 10), is_dual=(True, False)),
+        fundamental_basis_from_shape((10, 10), is_dual=(True, True)),
     ],
 )
 def test_linalg_diagonal(
@@ -157,10 +157,10 @@ def test_linalg_diagonal(
 @pytest.mark.parametrize(
     "basis",
     [
-        fundamental_tuple_basis_from_shape((10, 10)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(False, True)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(True, False)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(True, True)),
+        fundamental_basis_from_shape((10, 10)),
+        fundamental_basis_from_shape((10, 10), is_dual=(False, True)),
+        fundamental_basis_from_shape((10, 10), is_dual=(True, False)),
+        fundamental_basis_from_shape((10, 10), is_dual=(True, True)),
     ],
 )
 def test_linalg_complex_hermitian(
@@ -182,10 +182,10 @@ def test_linalg_complex_hermitian(
 @pytest.mark.parametrize(
     "basis",
     [
-        fundamental_tuple_basis_from_shape((10, 10)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(False, True)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(True, False)),
-        fundamental_tuple_basis_from_shape((10, 10), dual=(True, True)),
+        fundamental_basis_from_shape((10, 10)),
+        fundamental_basis_from_shape((10, 10), is_dual=(False, True)),
+        fundamental_basis_from_shape((10, 10), is_dual=(True, False)),
+        fundamental_basis_from_shape((10, 10), is_dual=(True, True)),
     ],
 )
 def test_linalg_real_hermitian(

--- a/tests/slate_array_test.py
+++ b/tests/slate_array_test.py
@@ -9,8 +9,7 @@ from slate.array import SlateArray
 from slate.array._transpose import transpose
 from slate.array._util import conjugate
 from slate.basis import (
-    FundamentalBasis,
-    fundamental_tuple_basis_from_shape,
+    fundamental_basis_from_shape,
 )
 from slate.basis.transformed import fundamental_transformed_tuple_basis_from_shape
 
@@ -37,14 +36,14 @@ def test_slate_array_dtype(
 def test_slate_array_basis(
     slate_array_integer: SlateArray[SimpleMetadata, np.int64],
 ) -> None:
-    assert slate_array_integer.basis == fundamental_tuple_basis_from_shape(
+    assert slate_array_integer.basis == fundamental_basis_from_shape(
         slate_array_integer.fundamental_shape
     )
 
 
 def test_create_array_with_wrong_size() -> None:
     with pytest.raises(AssertionError):
-        SlateArray(FundamentalBasis.from_shape((2, 3)), np.array([1, 2, 3, 4]))
+        SlateArray(fundamental_basis_from_shape((2, 3)), np.array([1, 2, 3, 4]))
 
 
 def test_create_array_shape(sample_data: np.ndarray[Any, np.dtype[np.int64]]) -> None:
@@ -55,8 +54,8 @@ def test_create_array_shape(sample_data: np.ndarray[Any, np.dtype[np.int64]]) ->
 @pytest.mark.parametrize(
     "basis",
     [
-        fundamental_tuple_basis_from_shape((2, 3)),
-        fundamental_tuple_basis_from_shape((2, 3), dual=(False, True)),
+        fundamental_basis_from_shape((2, 3)),
+        fundamental_basis_from_shape((2, 3), is_dual=(False, True)),
         fundamental_transformed_tuple_basis_from_shape((2, 3)),
     ],
 )
@@ -81,8 +80,8 @@ def test_transpose_array(
 @pytest.mark.parametrize(
     "basis",
     [
-        fundamental_tuple_basis_from_shape((2, 3)),
-        fundamental_tuple_basis_from_shape((2, 3), dual=(False, True)),
+        fundamental_basis_from_shape((2, 3)),
+        fundamental_basis_from_shape((2, 3), is_dual=(False, True)),
         fundamental_transformed_tuple_basis_from_shape((2, 3)),
     ],
 )

--- a/tests/split_array_test.py
+++ b/tests/split_array_test.py
@@ -10,7 +10,7 @@ from slate.basis import (
     diagonal_basis,
     tuple_basis,
 )
-from slate.basis._tuple import fundamental_tuple_basis_from_metadata
+from slate.basis._tuple import fundamental_basis_from_metadata
 from slate.basis.split import SplitBasis
 
 
@@ -33,7 +33,7 @@ def test_split_array_equals_transformed() -> None:
 
     diagonal = array.with_basis(DiagonalBasis(array.basis))
     fundamental = DiagonalBasis(
-        fundamental_tuple_basis_from_metadata(array.basis.metadata()),
+        fundamental_basis_from_metadata(array.basis.metadata()),
     )
     split = SlateArray(
         SplitBasis(fundamental, diagonal.basis),


### PR DESCRIPTION
The current approach using a single Boolean is_dual is not appropriate for nested basis types - in this case the basis is dual/not dual based on the individual fundamental axes.

With this PR we solve this problem, by introducing a nested is_dual specification. Note that now the conventions for FundamentalBasis are no longer linked to the dual flag, and we revert back to forward and backward specification.