### PR TITLE
Small Fixes

### DIFF
--- a/slate/array/__init__.py
+++ b/slate/array/__init__.py
@@ -19,7 +19,7 @@ from slate.array._conversion import (
     with_basis,
 )
 from slate.array._stats import average, standard_deviation
-from slate.array._transpose import conjugate, transpose
+from slate.array._transpose import conjugate, dagger, transpose
 
 __all__ = [
     "Array",
@@ -35,6 +35,7 @@ __all__ = [
     "average",
     "cast_basis",
     "conjugate",
+    "dagger",
     "flatten",
     "nest",
     "standard_deviation",

--- a/slate/array/_array.py
+++ b/slate/array/_array.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Never, cast, overload
 
 import numpy as np
 
 from slate import basis
 from slate.basis import Basis, TupleBasis
-from slate.metadata import BasisMetadata, NestedLength, shallow_shape_from_nested
+from slate.metadata import (
+    BasisMetadata,
+    Metadata2D,
+    NestedLength,
+    shallow_shape_from_nested,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from slate.basis._tuple import TupleBasis2D
     from slate.metadata import SimpleMetadata, StackedMetadata
+    from slate.metadata.stacked import Metadata1D, Metadata3D
 
 
 class Array[
@@ -58,11 +67,9 @@ class Array[
 
     def as_array(self) -> np.ndarray[Any, np.dtype[DT]]:
         """Get the data as a (full) np.array."""
-        metadata = self.basis.metadata()
-        fundamental = basis.from_metadata(metadata, is_dual=self.basis.is_dual)
+        fundamental = basis.as_fundamental(self.basis)
         shape = shallow_shape_from_nested(fundamental.fundamental_shape)
-        converted = self.basis.__convert_vector_into__(self._data, fundamental)
-        return converted.reshape(shape)
+        return self.with_basis(fundamental).raw_data.reshape(shape)
 
     @staticmethod
     def from_array[DT1: np.generic](
@@ -112,3 +119,44 @@ class Array[
         as_mul_basis = basis.as_mul_basis(self.basis)
         data = as_mul_basis.mul_data(self.with_basis(as_mul_basis).raw_data, other)
         return Array(as_mul_basis, data)
+
+    @overload
+    def __iter__[_DT: np.generic](
+        self: Array[Metadata1D[Any, Any], _DT, Basis[Any, Any]], /
+    ) -> Never: ...
+    @overload
+    def __iter__[_M1: BasisMetadata, _DT: np.generic](
+        self: Array[Metadata2D[Any, _M1, Any], _DT, Basis[Any, Any]], /
+    ) -> Iterator[Array[Basis[_M1, Any], _DT]]: ...
+    @overload
+    def __iter__[_M1: BasisMetadata, _M2: BasisMetadata, _DT: np.generic](
+        self: Array[Metadata3D[Any, _M1, _M2, Any], _DT, Basis[Any, Any]], /
+    ) -> Iterator[
+        Array[TupleBasis2D[Any, Basis[_M1, Any], Basis[_M2, Any], Any], _DT]
+    ]: ...
+    @overload
+    def __iter__[_M1: BasisMetadata, _DT: np.generic](
+        self: Array[StackedMetadata[_M1, Any], _DT, Basis[_M1, Any]], /
+    ) -> Iterator[Array[StackedMetadata[_M1, None], _DT]]: ...
+
+    def __iter__(
+        self: Array[Any, Any, Basis[BasisMetadata, Any]], /
+    ) -> Iterator[Array[Any, Any]]:
+        basis_as_tuple = basis.with_modified_child(
+            basis.as_tuple_basis(self.basis), basis.as_fundamental, 0
+        )
+        as_tuple = self.with_basis(basis_as_tuple)
+        children = as_tuple.basis.children[1:]
+        match len(children):
+            case 0:
+                msg = "Cannot iterate over a flat array."
+                raise ValueError(msg)
+            case 1:
+                out_basis = children[0]
+            case _:
+                out_basis = basis.tuple_basis(children)
+
+        return (
+            Array(out_basis, row)
+            for row in as_tuple.raw_data.reshape(as_tuple.basis.shape)
+        )

--- a/slate/array/_transpose.py
+++ b/slate/array/_transpose.py
@@ -4,13 +4,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from slate import basis
 from slate.array._array import Array
+from slate.array._conversion import as_diagonal_basis, as_index_basis, as_tuple_basis
 from slate.basis import (
     Basis,
     TupleBasis2D,
-    as_diagonal_basis,
-    as_tuple_basis,
     tuple_basis,
 )
 from slate.basis._diagonal import DiagonalBasis, diagonal_basis
@@ -24,7 +22,7 @@ def conjugate[M: BasisMetadata, DT: np.generic](
     array: Array[M, DT],
 ) -> Array[M, DT]:
     """Conjugate a slate array."""
-    converted = array.with_basis(basis.as_index_basis(array.basis))
+    converted = as_index_basis(array)
     return Array(converted.basis, np.conj(converted.raw_data)).with_basis(array.basis)
 
 
@@ -60,12 +58,11 @@ def transpose[M1: BasisMetadata, M2: BasisMetadata, E, DT: np.generic](
     array: Array[Metadata2D[M1, M2, E], DT],
 ) -> Array[Metadata2D[M1, M2, E], DT]:
     """Transpose a slate array."""
-    basis_as_diagonal = as_diagonal_basis(array.basis)
-    if basis_as_diagonal is not None:
-        return _transpose_from_diagonal(array.with_basis(basis_as_diagonal))
+    as_diagonal = as_diagonal_basis(array)
+    if as_diagonal is not None:
+        return _transpose_from_diagonal(as_diagonal)
 
-    basis_as_tuple = as_tuple_basis(array.basis)
-    return _transpose_from_tuple(array.with_basis(basis_as_tuple))
+    return _transpose_from_tuple(as_tuple_basis(array))
 
 
 def _inv_from_diagonal[M0: BasisMetadata, M1: BasisMetadata, E, DT: np.generic](
@@ -105,9 +102,15 @@ def inv[M1: BasisMetadata, M2: BasisMetadata, E, DT: np.generic](
     array: Array[Metadata2D[M1, M2, E], DT],
 ) -> Array[Metadata2D[M1, M2, E], DT]:
     """Inverse a slate array."""
-    basis_as_diagonal = as_diagonal_basis(array.basis)
-    if basis_as_diagonal is not None:
-        return _inv_from_diagonal(array.with_basis(basis_as_diagonal))
+    as_diagonal = as_diagonal_basis(array)
+    if as_diagonal is not None:
+        return _inv_from_diagonal(as_diagonal)
 
-    basis_as_tuple = as_tuple_basis(array.basis)
-    return _inv_from_tuple(array.with_basis(basis_as_tuple))
+    return _inv_from_tuple(as_tuple_basis(array))
+
+
+def dagger[M1: BasisMetadata, M2: BasisMetadata, E, DT: np.generic](
+    array: Array[Metadata2D[M1, M2, E], DT],
+) -> Array[Metadata2D[M1, M2, E], DT]:
+    """Conjugate Transpose a slate array."""
+    return conjugate(transpose(array))

--- a/slate/basis/__init__.py
+++ b/slate/basis/__init__.py
@@ -21,24 +21,25 @@ from slate.basis._tuple import (
     TupleBasis2D,
     TupleBasis3D,
     TupleBasisND,
-    as_fundamental,
+    as_feature_basis,
+    as_index_basis,
     as_tuple_basis,
-    flatten,
     from_metadata,
+    tuple_basis,
+)
+from slate.basis._util import (
+    as_add_basis,
+    as_fundamental,
+    as_is_dual_basis,
+    as_mul_basis,
+    as_sub_basis,
+    flatten,
     from_shape,
     get_common_basis,
-    tuple_basis,
     tuple_basis_is_variadic,
     with_child,
     with_modified_child,
     with_modified_children,
-)
-from slate.basis._util import (
-    as_add_basis,
-    as_feature_basis,
-    as_index_basis,
-    as_mul_basis,
-    as_sub_basis,
 )
 from slate.basis.coordinate import CoordinateBasis
 from slate.basis.cropped import CroppedBasis
@@ -86,6 +87,7 @@ __all__ = [
     "as_feature_basis",
     "as_fundamental",
     "as_index_basis",
+    "as_is_dual_basis",
     "as_mul_basis",
     "as_state_list",
     "as_sub_basis",

--- a/slate/basis/_isotropic.py
+++ b/slate/basis/_isotropic.py
@@ -48,7 +48,7 @@ class IsotropicBasis[
         displacement_matrix = np.mod(indices[:, None] - indices[None, :], self.size)
         return (
             swapped[displacement_matrix]
-            .reshape(-1, swapped.shape[1:])
+            .reshape(-1, *swapped.shape[1:])
             .swapaxes(axis, 0)
         )
 

--- a/slate/basis/_util.py
+++ b/slate/basis/_util.py
@@ -1,25 +1,266 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from itertools import starmap
+from typing import (
+    Any,
+    Callable,
+    Literal,
+    TypeGuard,
+    cast,
+    overload,
+)
 
 import numpy as np
 
-from slate.basis._tuple import from_metadata
-from slate.basis.wrapped import wrapped_basis_iter_inner
-from slate.metadata import BasisMetadata
+from slate.basis._basis import Basis, NestedBool
+from slate.basis._tuple import (
+    TupleBasis,
+    TupleBasis1D,
+    TupleBasis2D,
+    TupleBasis3D,
+    TupleBasisND,
+    as_feature_basis,
+    as_tuple_basis,
+    from_metadata,
+    tuple_basis,
+)
+from slate.basis.wrapped import (
+    wrapped_basis_iter_inner,
+)
+from slate.metadata import (
+    AnyMetadata,
+    BasisMetadata,
+    Metadata1D,
+    NestedLength,
+    SimpleMetadata,
+    StackedMetadata,
+)
 
-if TYPE_CHECKING:
-    from slate.basis._basis import Basis, BasisFeature
+
+@overload
+def tuple_basis_is_variadic[M: BasisMetadata, E, DT: np.generic](
+    basis: TupleBasis[M, E, DT], *, n_dim: Literal[1]
+) -> TypeGuard[TupleBasis1D[DT, Basis[M, DT], E]]: ...
+@overload
+def tuple_basis_is_variadic[M: BasisMetadata, E, DT: np.generic](
+    basis: TupleBasis[M, E, DT], *, n_dim: Literal[2]
+) -> TypeGuard[TupleBasis2D[DT, Basis[M, DT], Basis[M, DT], E]]: ...
+@overload
+def tuple_basis_is_variadic[M: BasisMetadata, E, DT: np.generic](
+    basis: TupleBasis[M, E, DT], *, n_dim: Literal[3]
+) -> TypeGuard[TupleBasis3D[DT, Basis[M, DT], Basis[M, DT], Basis[M, DT], E]]: ...
+@overload
+def tuple_basis_is_variadic[M: BasisMetadata, E, DT: np.generic](
+    basis: TupleBasis[M, E, DT], *, n_dim: int | None = None
+) -> TypeGuard[TupleBasisND[Any, E]]: ...
 
 
-def as_feature_basis[M: BasisMetadata, DT: np.generic](
-    basis: Basis[M, DT], features: set[BasisFeature]
-) -> Basis[M, DT]:
-    """Get the closest basis that supports the feature set."""
-    return next(
-        (b for b in wrapped_basis_iter_inner(basis) if features <= b.features),
-        from_metadata(basis.metadata(), is_dual=basis.is_dual),
+def tuple_basis_is_variadic(
+    basis: TupleBasis[Any, Any, Any], *, n_dim: int | None = None
+) -> TypeGuard[Any]:
+    """Cast a TupleBasis as a VariadicTupleBasis."""
+    return n_dim is None or len(basis.shape) == n_dim
+
+
+def with_modified_children[
+    M: BasisMetadata,
+    E,
+    DT: np.generic,
+    DT1: np.generic,
+](
+    basis: TupleBasis[M, E, DT1], wrapper: Callable[[int, Basis[M, DT1]], Basis[M, DT]]
+) -> TupleBasis[M, E, DT]:
+    """Get the basis with modified children."""
+    return TupleBasis[M, E, DT](
+        tuple(starmap(wrapper, enumerate(basis.children))), basis.metadata().extra
     )
+
+
+def with_modified_child[
+    M: BasisMetadata,
+    E,
+    DT: np.generic,
+    DT1: np.generic,
+](
+    basis: TupleBasis[M, E, DT],
+    wrapper: Callable[[Basis[M, DT]], Basis[M, DT1]],
+    idx: int,
+) -> TupleBasis[M, E, DT | DT1]:
+    """Get the basis with modified child."""
+    return with_modified_children(
+        basis, lambda i, b: cast("Basis[Any, Any]", b if i != idx else wrapper(b))
+    )
+
+
+def with_child[M: BasisMetadata, E, DT: np.generic](
+    basis: TupleBasis[M, E, DT], inner: Basis[M, DT], idx: int
+) -> TupleBasis[M, E, DT]:
+    """Get a basis with the basis at idx set to inner."""
+    return with_modified_child(basis, lambda _: inner, idx)
+
+
+def as_fundamental[M: AnyMetadata, DT: np.generic](
+    basis: Basis[M, DT],
+) -> Basis[M, np.generic]:
+    return from_metadata(basis.metadata(), is_dual=basis.is_dual)
+
+
+@overload
+def from_shape[E](
+    shape: tuple[int], *, extra: None = None, is_dual: tuple[bool, ...] | None = None
+) -> TupleBasis1D[np.generic, Basis[SimpleMetadata, np.generic], None]: ...
+
+
+@overload
+def from_shape[E](
+    shape: tuple[int], *, extra: E, is_dual: tuple[bool, ...] | None = None
+) -> TupleBasis1D[np.generic, Basis[SimpleMetadata, np.generic], E]: ...
+
+
+@overload
+def from_shape[E](
+    shape: tuple[int, int],
+    *,
+    extra: None = None,
+    is_dual: tuple[bool, ...] | None = None,
+) -> TupleBasis2D[
+    np.generic,
+    Basis[SimpleMetadata, np.generic],
+    Basis[SimpleMetadata, np.generic],
+    None,
+]: ...
+
+
+@overload
+def from_shape[E](
+    shape: tuple[int, int], *, extra: E, is_dual: tuple[bool, ...] | None = None
+) -> TupleBasis2D[
+    np.generic,
+    Basis[SimpleMetadata, np.generic],
+    Basis[SimpleMetadata, np.generic],
+    E,
+]: ...
+
+
+@overload
+def from_shape[E](
+    shape: tuple[int, int, int],
+    *,
+    extra: None = None,
+    is_dual: tuple[bool, ...] | None = None,
+) -> TupleBasis3D[
+    np.generic,
+    Basis[SimpleMetadata, np.generic],
+    Basis[SimpleMetadata, np.generic],
+    Basis[SimpleMetadata, np.generic],
+    None,
+]: ...
+
+
+@overload
+def from_shape[E](
+    shape: tuple[int, int, int], *, extra: E, is_dual: tuple[bool, ...] | None = None
+) -> TupleBasis3D[
+    np.generic,
+    Basis[SimpleMetadata, np.generic],
+    Basis[SimpleMetadata, np.generic],
+    Basis[SimpleMetadata, np.generic],
+    E,
+]: ...
+
+
+@overload
+def from_shape[E](
+    shape: tuple[int, ...],
+    *,
+    extra: None = None,
+    is_dual: tuple[bool, ...] | None = None,
+) -> TupleBasis[BasisMetadata, None, np.generic]: ...
+
+
+@overload
+def from_shape[E](
+    shape: tuple[int, ...], *, extra: E, is_dual: tuple[bool, ...] | None = None
+) -> TupleBasis[BasisMetadata, E, np.generic]: ...
+
+
+@overload
+def from_shape[E](
+    shape: NestedLength, *, extra: None = None, is_dual: tuple[bool, ...] | None = None
+) -> Basis[BasisMetadata, np.generic]: ...
+
+
+def from_shape[E](
+    shape: NestedLength,
+    *,
+    extra: Any | None = None,
+    is_dual: tuple[bool, ...] | None = None,
+) -> Any:
+    """Get a basis with the basis at idx set to inner."""
+    return from_metadata(
+        StackedMetadata.from_shape(shape, extra=extra), is_dual=is_dual
+    )
+
+
+def get_common_basis[M: BasisMetadata, E, DT: np.generic](
+    lhs: Basis[M, DT],
+    rhs: Basis[M, DT],
+) -> Basis[M, DT]:
+    """Get the closest common basis of two bases."""
+    assert rhs.metadata() == lhs.metadata()
+    lhs_rev = list(wrapped_basis_iter_inner(lhs))
+    rhs_rev = list(wrapped_basis_iter_inner(rhs))
+
+    if (
+        isinstance(lhs_rev[-1], TupleBasis)
+        and isinstance(rhs_rev[-1], TupleBasis)
+        and lhs_rev != rhs_rev
+    ):
+        # For a TupleBasis, we can do a bit better
+        # By finding the common basis of the children
+        lhs_children = cast("tuple[Basis[Any, Any], ...]", lhs_rev[-1].children)  # type: ignore unknown
+        rhs_children = cast("tuple[Basis[Any, Any], ...]", rhs_rev[-1].children)  # type: ignore unknown
+
+        basis = tuple_basis(
+            tuple(starmap(get_common_basis, zip(lhs_children, rhs_children))),
+            cast("StackedMetadata[Any, Any]", rhs.metadata()).extra,
+        )
+        return cast("Basis[M, DT]", basis)
+
+    last_common = from_metadata(rhs.metadata(), is_dual=rhs.is_dual)
+    for a, b in zip(reversed(lhs_rev), reversed(rhs_rev)):
+        if a != b:
+            return last_common
+        last_common = a
+    return last_common
+
+
+@overload
+def flatten[B: Basis[Any, Any], DT: np.generic](
+    basis: TupleBasis1D[Any, B, Any],
+) -> B: ...
+
+
+@overload
+def flatten[M: BasisMetadata, DT: np.generic](
+    basis: Basis[Metadata1D[M, Any], DT],
+) -> Basis[M, DT]: ...
+
+
+@overload
+def flatten[M: BasisMetadata, DT: np.generic](
+    basis: Basis[StackedMetadata[StackedMetadata[M, Any], Any], DT],
+) -> TupleBasis[M, None, DT]: ...
+
+
+def flatten(
+    basis: Basis[BasisMetadata, Any],
+) -> Basis[Any, Any]:
+    as_tuple = as_tuple_basis(basis)
+    if len(as_tuple.shape) == 1:
+        return as_tuple.children[0]
+    children = tuple(c for b in as_tuple.children for c in as_tuple_basis(b).children)
+    return tuple_basis(children)
 
 
 def as_add_basis[M: BasisMetadata, DT: np.generic](
@@ -58,13 +299,29 @@ def as_mul_basis[M: BasisMetadata, DT: np.generic](
     return as_feature_basis(basis, {"MUL"})
 
 
-def as_index_basis[M: BasisMetadata, DT: np.generic](
-    basis: Basis[M, DT],
+def as_is_dual_basis[M: BasisMetadata, DT: np.generic](
+    basis: Basis[M, DT], is_dual: NestedBool
 ) -> Basis[M, DT]:
-    """Get the closest basis that supports INDEX.
+    """Get the closest basis that supports IS_DUAL.
 
-    If the basis is already an INDEX basis, return it.
-    If it wraps a INDEX basis, return the inner basis.
+    If the basis is already an IS_DUAL basis, return it.
+    If it wraps an IS_DUAL basis, return the inner basis.
     Otherwise, return the fundamental.
     """
-    return as_feature_basis(basis, {"INDEX"})
+    if is_dual == basis.is_dual:
+        return basis
+    if isinstance(is_dual, bool):
+        assert isinstance(basis.is_dual, bool)
+        return basis.dual_basis()
+    assert isinstance(basis.is_dual, tuple)
+
+    basis_as_tuple = as_tuple_basis(
+        cast("Basis[StackedMetadata[Any, Any], Any]", basis)
+    )
+    return cast(
+        "Basis[M, DT]",
+        tuple_basis(
+            tuple(starmap(as_is_dual_basis, zip(basis_as_tuple.children, is_dual))),
+            basis_as_tuple.metadata().extra,
+        ),
+    )

--- a/slate/basis/recast.py
+++ b/slate/basis/recast.py
@@ -37,6 +37,19 @@ class RecastBasis[
 
         assert self._inner_recast.size == self.inner.size
 
+    @override
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, RecastBasis)
+            and self.inner == other.inner  # type: ignore unknown
+            and self.inner_recast == other.inner_recast  # type: ignore unknown
+            and self.outer_recast == other.outer_recast  # type: ignore unknown
+        )
+
+    @override
+    def __hash__(self) -> int:
+        return hash((self.inner, self.inner_recast, self.outer_recast))
+
     @property
     @override
     def size(self) -> int:

--- a/slate/basis/split.py
+++ b/slate/basis/split.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Never, Self, cast, override
 import numpy as np
 
 from slate.basis._basis import Basis, BasisFeature
-from slate.basis._tuple import get_common_basis
+from slate.basis._util import get_common_basis
 from slate.basis.transformed import TransformedBasis
 from slate.basis.wrapped import WrappedBasis
 from slate.util import Padding, pad_along_axis, slice_along_axis

--- a/slate/basis/transformed.py
+++ b/slate/basis/transformed.py
@@ -189,6 +189,12 @@ def fundamental_transformed_tuple_basis_from_metadata[M0: SimpleMetadata, E](
 
 
 @overload
+def fundamental_transformed_tuple_basis_from_metadata[M0: BasisMetadata, E](
+    metadata: Metadata1D[M0, E], *, is_dual: NestedBoolOrNone = None
+) -> TupleBasis1D[np.generic, Basis[M0, np.complex128], E]: ...
+
+
+@overload
 def fundamental_transformed_tuple_basis_from_metadata[
     M0: SimpleMetadata,
     M1: SimpleMetadata,
@@ -196,6 +202,18 @@ def fundamental_transformed_tuple_basis_from_metadata[
 ](
     metadata: Metadata2D[M0, M1, E], *, is_dual: NestedBoolOrNone = None
 ) -> TupleBasis2D[np.generic, TransformedBasis[M0], TransformedBasis[M1], E]: ...
+
+
+@overload
+def fundamental_transformed_tuple_basis_from_metadata[
+    M0: BasisMetadata,
+    M1: BasisMetadata,
+    E,
+](
+    metadata: Metadata2D[M0, M1, E], *, is_dual: NestedBoolOrNone = None
+) -> TupleBasis2D[
+    np.generic, Basis[M0, np.complex128], Basis[M1, np.complex128], E
+]: ...
 
 
 @overload
@@ -211,6 +229,23 @@ def fundamental_transformed_tuple_basis_from_metadata[
     TransformedBasis[M0],
     TransformedBasis[M1],
     TransformedBasis[M2],
+    E,
+]: ...
+
+
+@overload
+def fundamental_transformed_tuple_basis_from_metadata[
+    M0: BasisMetadata,
+    M1: BasisMetadata,
+    M2: BasisMetadata,
+    E,
+](
+    metadata: Metadata3D[M0, M1, M2, E], *, is_dual: NestedBoolOrNone = None
+) -> TupleBasis3D[
+    np.generic,
+    Basis[M0, np.complex128],
+    Basis[M1, np.complex128],
+    Basis[M2, np.complex128],
     E,
 ]: ...
 

--- a/slate/linalg/_einstein_index.py
+++ b/slate/linalg/_einstein_index.py
@@ -29,7 +29,7 @@ def _parse_einsum_tokens(tokens: list[str], idx: int = 0) -> tuple[NestedTokens,
 @dataclass(frozen=True)
 class EinsteinIndex:
     label: str
-    is_dual: bool
+    is_dual: bool = False
 
 
 type NestedEinsteinIndex = EinsteinIndex | tuple[NestedEinsteinIndex, ...]

--- a/slate/linalg/_einsum.py
+++ b/slate/linalg/_einsum.py
@@ -8,11 +8,11 @@ import numpy as np
 from slate.array import Array
 from slate.basis import (
     Basis,
+    as_fundamental,
     as_index_basis,
     as_tuple_basis,
     tuple_basis,
 )
-from slate.basis._tuple import as_fundamental
 from slate.linalg._einstein_index import (
     EinsteinIndex,
     NestedEinsteinIndex,
@@ -75,18 +75,19 @@ def _resolve_einsum_basis(
 
 class EinsumBasisHints:
     def __init__(self) -> None:
-        self._map = defaultdict[str, list[Basis[Any, Any]]](list)
+        self._map = defaultdict[str, set[Basis[Any, Any]]](set)
 
     def add_hint(self, idx: EinsteinIndex, basis: Basis[Any, Any]) -> None:
-        self._map[idx.label].append(basis.dual_basis() if idx.is_dual else basis)
+        self._map[idx.label].add(basis.dual_basis() if idx.is_dual else basis)
 
     def resolve_basis_map(self) -> EinsumBasisMap:
         basis_map = EinsumBasisMap()
         for idx, bases in self._map.items():
-            if len(bases) == 1:
-                basis_map[EinsteinIndex(idx)] = as_index_basis(bases[0])
+            bases_list = list(bases)
+            if len(bases_list) == 1:
+                basis_map[EinsteinIndex(idx)] = as_index_basis(bases_list[0])
             else:
-                basis_map[EinsteinIndex(idx)] = as_fundamental(bases[0])
+                basis_map[EinsteinIndex(idx)] = as_fundamental(bases_list[0])
         return basis_map
 
 

--- a/slate/linalg/_misc.py
+++ b/slate/linalg/_misc.py
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
 
 def extract_diagonal[M: BasisMetadata, E, DT: np.generic](
     array: Array[Metadata2D[M, M, E], DT],
-) -> Array[M, DT, Basis[M, Any]] | None:
-    b = DiagonalBasis(basis.from_metadata(array.basis.metadata()))
+) -> Array[M, DT, Basis[M, Any]]:
+    b = DiagonalBasis(basis.as_tuple_basis(basis.as_fundamental(array.basis)))
     converted = array.with_basis(b)
 
     return Array(converted.basis.inner[1], converted.raw_data)

--- a/slate/metadata/volume/_volume.py
+++ b/slate/metadata/volume/_volume.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, cast
+from itertools import starmap
+from typing import Any, cast, override
 
 import numpy as np
 
@@ -35,6 +36,16 @@ class AxisDirections:
 
     def __post_init__(self) -> None:
         _assert_orthonormal(self.vectors)
+
+    @override
+    def __eq__(self, value: object) -> bool:
+        if isinstance(value, AxisDirections):
+            return all(starmap(np.allclose, zip(self.vectors, value.vectors)))
+        return False
+
+    @override
+    def __hash__(self) -> int:
+        return hash(tuple(tuple(x) for x in self.vectors))
 
 
 type VolumeMetadata = StackedMetadata[LengthMetadata, AxisDirections]

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from slate.array import Array, with_basis
-from slate.basis._tuple import (
+from slate.basis import (
     TupleBasis2D,
     as_tuple_basis,
     from_shape,
@@ -18,8 +18,7 @@ from slate.linalg._eig import (
 )
 
 if TYPE_CHECKING:
-    from slate.basis import TupleBasis
-    from slate.basis._basis import Basis
+    from slate.basis import Basis, TupleBasis
     from slate.metadata import BasisMetadata, SimpleMetadata, StackedMetadata
     from slate.metadata.stacked import Metadata2D
 


### PR DESCRIPTION
This PR introduces several improvements to the einsum solver

Einsum basis resolution is now done in three stages
- First a series of hints are gathered for the 
- The hints are used to find the 'optimal' basis for the einsum
- In a second pass, the shape of the optimal basis is resolved for each initial and final array in the einsum

For now, this resolution is very simple, and only resolves as_index_basis if a single basis hint is provided. In the future however this opens us up to further optimizations.